### PR TITLE
chore: Hide constructors which should not be picked by DI

### DIFF
--- a/src/ExternalSearch.Providers.PermId/PermIdExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.PermId/PermIdExternalSearchProvider.cs
@@ -51,13 +51,13 @@ namespace CluedIn.ExternalSearch.Providers.PermId
                 this.TokenProvider = new RoundRobinTokenProvider(nameBasedTokenProvider.ApiToken.Split(',', ';'));
         }
 
-        public PermIdExternalSearchProvider(IList<string> tokens)
+        private PermIdExternalSearchProvider(IList<string> tokens)
             : this(true)
         {
             this.TokenProvider = new RoundRobinTokenProvider(tokens);
         }
 
-        public PermIdExternalSearchProvider([NotNull] IExternalSearchTokenProvider tokenProvider)
+        private PermIdExternalSearchProvider([NotNull] IExternalSearchTokenProvider tokenProvider)
             : this(true)
         {
             this.TokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
@@ -94,7 +94,7 @@ namespace CluedIn.ExternalSearch.Providers.PermId
 
             //if (string.IsNullOrEmpty(this.TokenProvider.ApiToken))
             //    throw new InvalidOperationException("PermId ApiToken have not been configured");
- 
+
             var existingResults = request.GetQueryResults<PermIdSocialResponse>(this).ToList();
 
             Func<string, bool> existingDataFilter   = value => existingResults.Any(r => string.Equals(r.Data.OrganizationName.First(), value, StringComparison.InvariantCultureIgnoreCase));


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
When using the latest EasyNetQ in platform it installs the collection resolvers allowing empty sequences, so if you inject `IEnumerable<T>`, the container will generate you an instance for that even if `T` is not registered. That is a change from the previous behavior when empty collections would not be resolved for you.

The issue is that PermId provider constructor has multiple public overloads. And one of it is taking IEnumerable. Now Castle tries to pick this constructor to active the object.

I fixed that by hiding all the constructors but the default one. That's how it is with other enrichers. It seems that other constructors are not being used.