### PR TITLE
fix: Set organization name vocabulary key as mandatory

### DIFF
--- a/docs/4.5.1-release-notes.md
+++ b/docs/4.5.1-release-notes.md
@@ -1,0 +1,2 @@
+# Fixes
+- Set Organization Name Vocabulary Key as mandatory

--- a/src/ExternalSearch.Providers.PermId/Constants.cs
+++ b/src/ExternalSearch.Providers.PermId/Constants.cs
@@ -86,7 +86,7 @@ namespace CluedIn.ExternalSearch.Providers.PermId
                 {
                     DisplayName = "Organization Name Vocabulary Key",
                     Type = "vocabularyKeySelector",
-                    IsRequired = false,
+                    IsRequired = true,
                     Name = KeyName.OrganizationName,
                     Help = "The vocabulary key that contains the names of companies you want to enrich (e.g., organization.name)."
                 }


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
<!-- Remove Work Item ID if not needed -->
Work Item ID: [AB#48883](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/48883)

After updating:
![image](https://github.com/user-attachments/assets/31ab5e33-8d34-48c2-92b8-6452d6fd1900)


## How has it been tested? <!-- Remove if not needed -->
Manually in local

