### PR TITLE
feat: Update to .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup Label="Compilation Metadata">
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <!-- TODO: Clean up warnings -->

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,5 +1,5 @@
 mode: ContinuousDeployment
-next-version: 4.0
+next-version: 5.0
 branches:
   hotfix:
     tag: useBranchName

--- a/Packages.props
+++ b/Packages.props
@@ -1,46 +1,15 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_ComponentHost>4.0.1</_ComponentHost>
     <_AutoFixture>5.0.0-preview0012</_AutoFixture>
     <_CluedIn>5.0.0-*</_CluedIn>
   </PropertyGroup>
-  <ItemGroup>
-    <!--
-        Specified versions for dependencies in test projects
-
-        MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
-    -->
-    <!--    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.3.0" />-->
-    <!--    <PackageReference Update="AutoFixture.Xunit3" Version="$(_AutoFixture)" />-->
-    <!--    <PackageReference Update="AutoFixture.Idioms" Version="$(_AutoFixture)" />-->
-    <!--    <PackageReference Update="AutoFixture.AutoMoq" Version="$(_AutoFixture)" />-->
-    <!--    <PackageReference Update="coverlet.msbuild" Version="2.8.0" />-->
-    <!--    <PackageReference Update="Serilog.Sinks.XUnit" Version="1.0.21" />-->
-    <!--    <PackageReference Update="xunit.v3" Version="3.2.2" />-->
-    <!--    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />-->
-    <!--    <PackageReference Update="Xunit.SkippableFact" Version="1.3.12" />-->
-    <!--    <PackageReference Update="Moq" Version="4.13.1" />-->
-    <!--    <PackageReference Update="Shouldly" Version="3.0.2" />-->
-    <!--    <PackageReference Update="CluedIn.Testing.Base" Version="4.0.0-alpha.3" />-->
-  </ItemGroup>
   <ItemGroup>
     <!--
         Specified versions for dependencies across the solution
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <PackageReference Update="ComponentHost" Version="$(_ComponentHost)" />
     <PackageReference Update="CluedIn.Core" Version="$(_CluedIn)" />
     <PackageReference Update="CluedIn.ExternalSearch" Version="$(_CluedIn)" />
-  </ItemGroup>
-  <ItemGroup Label="Global tools">
-    <!--
-            Automatically added to each project with :
-            - IncludeAssets="Analyzers;Build"
-            - PrivateAssets="All"
-
-            DO NOT NEED TO BE ADDED AS A PACKAGEREFERENCE
-        -->
-    <!-- <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" /> -->
   </ItemGroup>
 </Project>

--- a/Packages.props
+++ b/Packages.props
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup Label="Dependency Versions">
-    <_ComponentHost>3.2.1</_ComponentHost>
-    <_AutoFixture>4.11.0</_AutoFixture>
-    <_CluedIn>4.6.0</_CluedIn>
+    <_ComponentHost>4.0.1</_ComponentHost>
+    <_AutoFixture>5.0.0-preview0012</_AutoFixture>
+    <_CluedIn>5.0.0-*</_CluedIn>
   </PropertyGroup>
   <ItemGroup>
     <!--
@@ -10,14 +10,14 @@
 
         MUST SPECIFY IN CSPROJ AS <PackageReference Name="<depName>" />
     -->
-    <!--    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />-->
-    <!--    <PackageReference Update="AutoFixture.Xunit2" Version="$(_AutoFixture)" />-->
+    <!--    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="18.3.0" />-->
+    <!--    <PackageReference Update="AutoFixture.Xunit3" Version="$(_AutoFixture)" />-->
     <!--    <PackageReference Update="AutoFixture.Idioms" Version="$(_AutoFixture)" />-->
     <!--    <PackageReference Update="AutoFixture.AutoMoq" Version="$(_AutoFixture)" />-->
     <!--    <PackageReference Update="coverlet.msbuild" Version="2.8.0" />-->
     <!--    <PackageReference Update="Serilog.Sinks.XUnit" Version="1.0.21" />-->
-    <!--    <PackageReference Update="xunit" Version="2.4.1" />-->
-    <!--    <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />-->
+    <!--    <PackageReference Update="xunit.v3" Version="3.2.2" />-->
+    <!--    <PackageReference Update="xunit.runner.visualstudio" Version="3.1.5" />-->
     <!--    <PackageReference Update="Xunit.SkippableFact" Version="1.3.12" />-->
     <!--    <PackageReference Update="Moq" Version="4.13.1" />-->
     <!--    <PackageReference Update="Shouldly" Version="3.0.2" />-->

--- a/global.json
+++ b/global.json
@@ -1,8 +1,7 @@
 {
   "sdk": {
-    "version": "6.0.400",
-    "rollForward": "latestFeature",
-    "allowPrerelease": false
+    "version": "10.0.100",
+    "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
     "Microsoft.Build.CentralPackageVersions": "2.0.52"

--- a/src/ExternalSearch.Providers.PermId.Provider/ExternalSearch.Providers.PermId.Provider.csproj
+++ b/src/ExternalSearch.Providers.PermId.Provider/ExternalSearch.Providers.PermId.Provider.csproj
@@ -2,7 +2,6 @@
 
   <ItemGroup>
     <PackageReference Include="CluedIn.Core" />
-    <PackageReference Include="ComponentHost" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ExternalSearch.Providers.PermId/ExternalSearch.Providers.PermId.csproj
+++ b/src/ExternalSearch.Providers.PermId/ExternalSearch.Providers.PermId.csproj
@@ -6,7 +6,4 @@
     <PackageReference Include="CluedIn.Core" />
     <PackageReference Include="CluedIn.ExternalSearch" />
   </ItemGroup>
-  <PropertyGroup>
-    <LangVersion>preview</LangVersion>
-  </PropertyGroup>
 </Project>

--- a/src/ExternalSearch.Providers.PermId/PermIdExternalSearchProvider.cs
+++ b/src/ExternalSearch.Providers.PermId/PermIdExternalSearchProvider.cs
@@ -190,7 +190,7 @@ namespace CluedIn.ExternalSearch.Providers.PermId
 
             ActionExtensions.ExecuteWithRetry(() =>
             {
-                var request = new RestRequest(parameter, Method.GET);
+                var request = new RestRequest(parameter, Method.Get);
 
                 request.AddHeader("X-AG-Access-Token", apiKey);
 
@@ -266,7 +266,7 @@ namespace CluedIn.ExternalSearch.Providers.PermId
 
             var searchClient = new RestClient("https://api-eit.refinitiv.com/permid/search?q=Google");
             var socialClient = new RestClient("https://permid.org/api/mdaas/getEntityById/");
-            var request = new RestRequest(Method.GET);
+            var request = new RestRequest();
             request.AddHeader("X-AG-Access-Token", apiToken);
 
             var searchResponse = searchClient.Execute<PermIdSearchResponse>(request);
@@ -286,7 +286,7 @@ namespace CluedIn.ExternalSearch.Providers.PermId
 
             foreach (var permId in idList)
             {
-                request = new RestRequest(permId, Method.GET);
+                request = new RestRequest(permId, Method.Get);
                 request.AddHeader("X-AG-Access-Token", apiToken);
 
                 var socialResponse = socialClient.Execute<PermIdSearchResponse>(request);
@@ -299,7 +299,7 @@ namespace CluedIn.ExternalSearch.Providers.PermId
             return new ConnectionVerificationResult(true, string.Empty);
         }
 
-        private ConnectionVerificationResult ConstructVerifyConnectionResponse(IRestResponse response)
+        private ConnectionVerificationResult ConstructVerifyConnectionResponse(RestResponse response)
         {
             var errorMessageBase = $"{Constants.ProviderName} returned \"{(int)response.StatusCode} {response.StatusDescription}\".";
             if (response.ErrorException != null)

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture.Xunit2" Version="4.8.0" />
+    <PackageReference Include="AutoFixture.Xunit3" Version="4.8.0" />
     <PackageReference Include="coverlet.msbuild" Version="2.6.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
<!-- PR workflow process: https://dev.azure.com/CluedIn-io/CluedIn/_wiki/wikis/CluedIn.wiki/77/Pull-Request-Process -->

## Description
Work Item ID: [AB#56314](https://dev.azure.com/CluedIn-io/c054b4ae-1dab-43c2-af97-3683c744782f/_workitems/edit/56314)

Upgrade to .NET 10 (`net10.0`) and align with CluedIn platform 5.0.

- `global.json`: SDK updated to `10.0.100` with `rollForward: latestFeature`
- `Directory.Build.props`: `TargetFramework` changed to `net10.0`; `LangVersion` removed (defaults to C# 13)
- `gitversion.yml`: `next-version` bumped to `5.0`
- CluedIn package references updated to `5.0.0-*`